### PR TITLE
file:// strings displayed as active links, like http://

### DIFF
--- a/src/components/jsonview.js
+++ b/src/components/jsonview.js
@@ -94,7 +94,7 @@ JSONFormatter.prototype = {
       output += this.decorateWithSpan(value, 'num');
     }
     else if (valueType == 'string') {
-      if (/^(http|https):\/\/[^\s]+$/i.test(value)) {
+      if (/^(http|https|file):\/\/[^\s]+$/i.test(value)) {
         output += '<a href="' + value + '"><span class="q">"</span>' + this.jsString(value) + '<span class="q">"</span></a>';
       } else {
         output += '<span class="string">"' + this.jsString(value) + '"</span>';


### PR DESCRIPTION
Hi,
Thanks for jsonview - perfect tool. Here is a tiny little change that makes life easier: "file://..." strings are displayed now as active links, just like "http://...." - a lifesaver for myself (and possibly other users too), because I use local json files for storing complex debug logs, which contain links to local html files and thus making the links active is really helpful. Hope you can merge into master branch? It's tested, works.
