### PR TITLE
refactored the loop for rendering arrays

### DIFF
--- a/lib/jsonformatter.js
+++ b/lib/jsonformatter.js
@@ -68,34 +68,21 @@ JSONFormatter.prototype = {
 
   // Convert an array into an HTML fragment
   arrayToHTML: function(json, path) {
-    var hasContents = false;
-    var output = '';
-    var numProps = 0;
-    for (var prop in json) {
-      numProps++;
-    }
+    var output;
 
-    for (var prop in json) {
-      hasContents = true;
-      var subPath = '';
-      var escapedProp = JSON.stringify(prop).slice(1, -1);
-      if(/^[0-9]{1,}$/.test(prop)) {
-        subPath = path + '['+ escapedProp + ']';
-      } else {
-        subPath = path + '["' + escapedProp + '"]';
-      }
-      output += '<li>' + this.valueToHTML(json[prop], subPath);
-      if ( numProps > 1 ) {
-        output += ',';
-      }
-      output += '</li>';
-      numProps--;
-    }
-
-    if ( hasContents ) {
-      output = '<span class="collapser"></span>[<ul class="array collapsible">' + output + '</ul>]';
-    } else {
+    if ( json.length == 0 ) {
       output = '[ ]';
+    } else {
+      output = '';
+      for ( var i = 0; i < json.length; i++ ) {
+        var subPath = path + '[' + i + ']';
+        output += '<li>' + this.valueToHTML(json[i], subPath);
+        if ( i < json.length - 1 ) {
+          output += ',';
+        }
+        output += '</li>';
+      }
+      output = '<span class="collapser"></span>[<ul class="array collapsible">' + output + '</ul>]';
     }
 
     return output;


### PR DESCRIPTION
I refactored the loop which is responsible for building the HTML string for arrays.
I did this for two reasons:
- performance (iterate only once over the array)
- Accordance with the ECMA standard: the standard does not specify the order in which a `for(...in...)` loop returns the contents of an array (http://www.ecma-international.org/ecma-262/5.1/#sec-12.6.4).
