### PR TITLE
highlight the hovered and clicked nodes an their ancestors

### DIFF
--- a/data/default.css
+++ b/data/default.css
@@ -126,3 +126,11 @@ h1 {
   font-family: monospace;
   color: #A52A2A;
 }
+
+li.clicked {
+  background-color: rgba(128, 255, 128, 0.2);
+}
+
+li:hover {
+  background-color: rgba(128, 128, 255, 0.2);
+}

--- a/data/default.js
+++ b/data/default.js
@@ -6,6 +6,16 @@ document.addEventListener('DOMContentLoaded', function() {
   function collapse(evt) {
     var collapser = evt.target;
 
+    var clickeds = document.querySelectorAll('.clicked');
+    for(var i=0; i<clickeds.length; i++){
+      clickeds[i].classList.toggle('clicked');
+    }
+    for(var node = collapser; node.parentNode; node = node.parentNode){
+      if(node.classList){
+        node.classList.toggle('clicked');
+      } 
+    }
+
     while (collapser && (!collapser.classList || !collapser.classList.contains('collapser'))) {
       collapser = collapser.nextSibling;
     }


### PR DESCRIPTION
I added some background highlighting to keep track of where is everything in big JSONs.
It gives an increasingly darker background as it goes deeper. Blue for the hovered node:
![jsonview-hover](https://cloud.githubusercontent.com/assets/1610221/3239556/d9a426da-f10e-11e3-85cc-5b3f4cde0807.png)
And green for the clicked node (stays highlighted until you click somewhere else so you can scroll and keep track of it):
![jsonview-clicked-and-hover](https://cloud.githubusercontent.com/assets/1610221/3239555/d9a37a1e-f10e-11e3-8e98-4234a317dcf3.png)
