### PR TITLE
Show collapsed ellipsis again

### DIFF
--- a/data/default.css
+++ b/data/default.css
@@ -45,7 +45,7 @@ body {
 }
 
 .collapsible.collapsed {
-  height: .8em;
+  height: .9em;
   width: 1em;
   display: inline-block;
   overflow: hidden;


### PR DESCRIPTION
Small fix that shows the ellipsis (`...`) again when object is collapsed.

Great addon btw!