### PR TITLE
Render link when JSON key is `href`

### DIFF
--- a/lib/jsonformatter.js
+++ b/lib/jsonformatter.js
@@ -60,7 +60,7 @@ JSONFormatter.prototype = {
       return this.decorateWithSpan(value, 'num');
     }
     else if (valueType == 'string') {
-      if (/^(http|https|file):\/\/[^\s]+$/i.test(value)) {
+      if (/^(http|https|file):\/\/[^\s]+$/i.test(value) || /\bhref\b/.test(path)) {
         return '<a href="' + this.htmlEncode(value) + '"><span class="q">&quot;</span>' + this.jsString(value) + '<span class="q">&quot;</span></a>';
       } else {
         return '<span class="string">&quot;' + this.jsString(value) + '&quot;</span>';


### PR DESCRIPTION
This commit adds a test for JSON _key_ matching the word `href` where
there was already testing for a JSON _value_ matching a URL scheme.
## Background

As a heuristic, jsonview already renders links (`<a href … > … </a>`) when
JSON value begins with a known URL scheme (http, https, or file). However, this
heuristic misses relative URLs (In my case, specifically URLs with paths but
no authority part). A JSON _key_ of `href` may be a good (additional) heuristic
for when the corresponding _value_ is a URI.
