### PR TITLE
Ensure visible ellipsis for collapsed object/array

### DIFF
--- a/data/default.css
+++ b/data/default.css
@@ -49,6 +49,7 @@ body {
   width: 1em;
   display: inline-block;
   overflow: hidden;
+  vertical-align: top;
   margin: 0;
 }
 .collapsible.collapsed:before {

--- a/data/default.css
+++ b/data/default.css
@@ -45,7 +45,7 @@ body {
 }
 
 .collapsible.collapsed {
-  height: .9em;
+  height: 1.2em;
   width: 1em;
   display: inline-block;
   overflow: hidden;


### PR DESCRIPTION
Fix for #96.

*   `height: .8em` (original)

    ![height: 0.8em](https://cloud.githubusercontent.com/assets/1247730/7611768/4fbfa734-f98f-11e4-95ce-610c23d54439.png)

*   `height: .9em` (#83)

    ![height: 0.9em](https://cloud.githubusercontent.com/assets/1247730/7611808/82f762d6-f98f-11e4-8c0b-005edfd8f03f.png)

    _Doesn't appear to solve the problem._

*    `height: 1em`

    ![height: 1em](https://cloud.githubusercontent.com/assets/1247730/7611834/b71e02b8-f98f-11e4-8e00-093701c31fee.png)

    _Partially solves the problem._

*    `height: 1.2em`

    ![height: 1.2em](https://cloud.githubusercontent.com/assets/1247730/7611850/d0428b6a-f98f-11e4-8099-2b1fcfd266f9.png)

    _Appears to solve the problem._
