### PR TITLE
#97 Support Firefox multiprocess (electrolysis, e10s)

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -2,51 +2,22 @@
  * @author Benjamin Hollis
  * @author Quoc-Viet Nguyen
  */
-const { Cc, Ci, components } = require("chrome");
-const xpcom = require("sdk/platform/xpcom");
-const { JSONView } = require("./jsonview");
-const prefs = require("./prefs");
+const { Cu, Cc, Ci, components } = require("chrome");
 
-// This component is an implementation of nsIStreamConverter that converts
-// application/json to html
-const JSON_TYPE = "application/json";
-const CONTRACT_ID = "@mozilla.org/streamconv;1?from=" + JSON_TYPE + "&to=*/*";
-const CLASS_ID = "{64890660-53c4-11dd-ae16-0800200c9a66}";
-const GECKO_VIEWER = "Gecko-Content-Viewers";
+// Platform
+const globalMM = Cc["@mozilla.org/globalmessagemanager;1"].
+  getService(Ci.nsIMessageListenerManager);
 
-// Create and register the service
-var service = xpcom.Service({
-  id: components.ID(CLASS_ID),
-  contract: CONTRACT_ID,
-  Component: JSONView,
-  register: false,
-  unregister: false
-});
-
-// Hack to remove FF8+'s built-in JSON-as-text viewer
-var categoryManager = Cc["@mozilla.org/categorymanager;1"].getService(Ci.nsICategoryManager);
-var geckoViewer = categoryManager.getCategoryEntry(GECKO_VIEWER, JSON_TYPE);
+const url = module.uri.replace("main.js", "registrar.js");
 
 function onLoad(options, callbacks) {
-  console.debug(options.loadReason);
-  if (!xpcom.isRegistered(service)) {
-    xpcom.register(service);
-  }
-  // Remove built-in JSON viewer
-  categoryManager.deleteCategoryEntry(GECKO_VIEWER, JSON_TYPE, false);
-  
-  // Tell Firefox that .json files are application/json
-  categoryManager.addCategoryEntry('ext-to-type-mapping', 'json', 'application/json', false, true);
-  prefs.register();
+  globalMM.loadFrameScript(url, true);
+  globalMM.broadcastAsyncMessage("jsonview-onload");
 };
 
 function onUnload(reason) {
-  if (xpcom.isRegistered(service)) {
-    xpcom.unregister(service);
-  }
-  // Re-add built-in JSON viewer
-  categoryManager.addCategoryEntry(GECKO_VIEWER, JSON_TYPE, geckoViewer, false, false);
-  prefs.unregister();
+  globalMM.broadcastAsyncMessage("jsonview-onunload");
+  globalMM.removeDelayedFrameScript(url);
 };
 
 exports.main = onLoad;

--- a/lib/registrar.js
+++ b/lib/registrar.js
@@ -1,0 +1,66 @@
+/**
+ * @author Benjamin Hollis
+ * @author Quoc-Viet Nguyen
+ */
+
+let Cu = Components.utils;
+let { devtools } = Cu.import("resource://gre/modules/devtools/Loader.jsm", {});
+let require = devtools.require;
+
+const { Cc, Ci, components } = require("chrome");
+const xpcom = require("sdk/platform/xpcom");
+const { JSONView } = require("resource://jsonview-at-brh-dot-numbera-dot-com/jsonview/lib/jsonview.js");
+const prefs = require("resource://jsonview-at-brh-dot-numbera-dot-com/jsonview/lib/prefs.js");
+
+// This component is an implementation of nsIStreamConverter that converts
+// application/json to html
+const JSON_TYPE = "application/json";
+const CONTRACT_ID = "@mozilla.org/streamconv;1?from=" + JSON_TYPE + "&to=*/*";
+const CLASS_ID = "{64890660-53c4-11dd-ae16-0800200c9a66}";
+const GECKO_VIEWER = "Gecko-Content-Viewers";
+
+// Create and register the service
+var service = xpcom.Service({
+  id: components.ID(CLASS_ID),
+  contract: CONTRACT_ID,
+  Component: JSONView,
+  register: false,
+  unregister: false
+});
+
+// Hack to remove FF8+'s built-in JSON-as-text viewer
+var categoryManager = Cc["@mozilla.org/categorymanager;1"].getService(Ci.nsICategoryManager);
+var geckoViewer;
+try {
+  geckoViewer = categoryManager.getCategoryEntry(GECKO_VIEWER, JSON_TYPE);
+} catch (err) {
+  // The category entry doesn't have to exist.
+}
+
+// Handle messages from the parent process.
+addMessageListener("jsonview-onload", onLoad);
+addMessageListener("jsonview-onunload", onUnload);
+
+function onLoad(options, callbacks) {
+  //console.debug(options.loadReason);
+  if (!xpcom.isRegistered(service)) {
+    xpcom.register(service);
+  }
+  // Remove built-in JSON viewer
+  categoryManager.deleteCategoryEntry(GECKO_VIEWER, JSON_TYPE, false);
+  
+  // Tell Firefox that .json files are application/json
+  categoryManager.addCategoryEntry('ext-to-type-mapping', 'json', 'application/json', false, true);
+  prefs.register();
+};
+
+function onUnload(reason) {
+  if (xpcom.isRegistered(service)) {
+    xpcom.unregister(service);
+  }
+  // Re-add built-in JSON viewer
+  if (geckoViewer) {
+    categoryManager.addCategoryEntry(GECKO_VIEWER, JSON_TYPE, geckoViewer, false, false);
+  }
+  prefs.unregister();
+};


### PR DESCRIPTION
Support for e10s implemented.

Note that I had troubles to build the final XPI using "cfx xpi" (some files seem to be missing in the final package). Not sure what could be wrong, but cfx is no longer supported and it's been replaced by JPM, so I would recommend to switch to JPM in any case.

Also the min max Firefox isn't set correctly (should be done in package.json).

Honza

