### PR TITLE
Documented `data:` trick

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Once you've got JSONView installed, check out [this example JSON file](http://js
 
 [CouchDB](http://couchdb.apache.org/) users and others who need to have `application/json` sent in the HTTP Accept header to serve JSON properly should set that option in JSONView's options panel. Be aware that telling sites that you accept JSON can mess up some sites that don't expect it.
 
+If you want to inspect a JSON snippet from your clipboard you can do so by entering `data:application/json,<paste the json document>` in the URL bar.
+
 If you'd like to contribute to JSONView but don't want to code, consider contributing a translation. Copy the existing localization files from `locale` and `src/locale` and fill them in for your own language, then send a pull request. You can do it all from the GitHub interface. There's not much there to translate!
 
 Keyboard Shortcuts


### PR DESCRIPTION
Just thought that someone else might be interested in this small trick, too:

You can inspect arbitrary JSON documents (f.e. from your clipboard) by using data urls.