### PR TITLE
check for lowercase header names.

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -50,7 +50,7 @@ function detectJSON(event: chrome.webRequest.WebResponseHeadersDetails) {
     return;
   }
   for (const header of event.responseHeaders) {
-    if (header.name === "Content-Type" && header.value && jsonContentType.test(header.value)) {
+    if (header.name.toLowerCase() === "content-type" && header.value && jsonContentType.test(header.value)) {
       if (typeof browser !== 'undefined' && 'filterResponseData' in browser.webRequest) {
         header.value = "text/html";
         transformResponseToJSON(event);


### PR DESCRIPTION
Hi there,

first: thanks for your work :-) Second: I had some difficulties with a web server which only returned header names in lowercase letters. The responses were/are similar to the one given here: https://stackoverflow.com/questions/5258977/are-http-headers-case-sensitive

So it would be nice to have the content type converted before making any checks.

Robert
