### PR TITLE
Fix build.sh to use bash and rm -f

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 tsc
 
@@ -14,7 +14,7 @@ cp license.txt build/license.txt
 cp -r src/_locales build
 cp src/icon*.png build
 
-rm jsonview.zip
+rm -f jsonview.zip
 pushd build
 zip -r ../jsonview.zip *
 popd


### PR DESCRIPTION
build.sh uses pushd/popd but is coded with /bin/sh; at least some
/bin/sh's don't support that.  Also, rm jsonview.zip fails if
the file doesn't exist; rm -f fixes that.

Fixes: https://github.com/bhollis/jsonview/issues/160
Signed-off-by: Dan Mick <dan.mick@redhat.com>