### PR TITLE
Do not read content type from redirect responses

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -15,6 +15,10 @@ const jsonContentType = /^application\/([a-z]+\+)?json($|;)/;
 // Keep track globally of URLs that contain JSON content.
 const jsonUrls = new Set<string>();
 
+function isRedirect(status: number) {
+  return status >= 300 && status < 400;
+}
+
 /** Use the filterResponseData API to transform a JSON document to HTML. */
 function transformResponseToJSON(details: chrome.webRequest.WebResponseHeadersDetails) {
   const filter = browser.webRequest.filterResponseData(details.requestId);
@@ -46,7 +50,7 @@ function transformResponseToJSON(details: chrome.webRequest.WebResponseHeadersDe
 }
 
 function detectJSON(event: chrome.webRequest.WebResponseHeadersDetails) {
-  if (!event.responseHeaders) {
+  if (!event.responseHeaders || isRedirect(event.statusCode)) {
     return;
   }
   for (const header of event.responseHeaders) {


### PR DESCRIPTION
The content type header is irrelevant for redirect (status 300 to 400)
responses, as they do not say anything about the content type of the
actual resource they redirect to.

This commit makes the extension silently ignore redirect responses. The
resource at the end of the redirect is still handled properly.

No special consideration is taken for status code 300 which will not
make the browser create a new request, as the response body for these
responses should already be made for display to the user.

Fixes #172

------

The following example server reproduces the problem described in #172, and also reveals a problem for the `/redirect-json/json` route. The PR fixes both the issues. I have only tested the issues and solution in Firefox 79.
```
const app = require('express')();

const redirect_json = Location => (_, res) =>
  res.status(303).set({'Content-Type': 'application/json', Location}).send();

app.get('/text', (_, res) => res.send('Text')); 
app.get('/json', (_, res) => res.send({'json': 'object'}));
app.get('/redirect/text', (_, res) => res.redirect('/text'));
app.get('/redirect/json', (_, res) => res.redirect('/json'));
app.get('/redirect-json/text', redirect_json('/text'));
app.get('/redirect-json/json', redirect_json('/json'));

app.listen(3000);
```