### PR TITLE
Add a dot in jsonContentType regex

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -10,7 +10,7 @@ import { safeStringEncodeNums } from './safe-encode-numbers';
 
 // Look for JSON if the content type is "application/json",
 // or "application/whatever+json" or "application/json; charset=utf-8"
-const jsonContentType = /^application\/([a-z]+\+)?json($|;)/;
+const jsonContentType = /^application\/([a-z.]+\+)?json($|;)/;
 
 // Keep track globally of URLs that contain JSON content.
 const jsonUrls = new Set<string>();


### PR DESCRIPTION
Some content types containing a dot are not recognized by the regex.
Adding a dot could add support for content types like `application/vdn.api+json`

Basically, `/^application\/([a-z]+\+)?json($|;)/` becomes `/^application\/([a-z.]+\+)?json($|;)/`