### PR TITLE
Update JSON MIME-type detection

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -10,7 +10,7 @@ import { safeStringEncodeNums } from './safe-encode-numbers';
 
 // Look for JSON if the content type is "application/json",
 // or "application/whatever+json" or "application/json; charset=utf-8"
-const jsonContentType = /^application\/([a-z.]+\+)?json($|;)/;
+const jsonContentType = /^application\/(\w!#$&\.-\^\+)?json($|;)/;
 
 // Keep track globally of URLs that contain JSON content.
 const jsonUrls = new Set<string>();


### PR DESCRIPTION
Per https://www.rfc-editor.org/rfc/rfc4288#section-4.2, the specs for a valid MIME-type allow for a few more characters.

This regex covers them.

Fixes #188 