### PR TITLE
Fix JSON Mime type regex

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -8,7 +8,7 @@
 
 // Look for JSON if the content type is "application/json",
 // or "application/whatever+json" or "application/json; charset=utf-8"
-const jsonContentType = /^application\/(\w!#$&\.-\^\+)?json($|;)/;
+const jsonContentType = /^application\/([\w!#$&.\-^+]+\+)?json($|;)/;
 
 // Keep track globally of URLs that contain JSON content.
 const jsonUrls = new Set<string>();


### PR DESCRIPTION
I think in https://github.com/bhollis/jsonview/pull/195 the mime-type regex got broken and no longer supports application/whatever+json format (despite it being claimed in comments above the code)

The reason I suspect is due to wrong regex capturing group where character class was removed ([abc] aka match any in [] brackets)

This is an attempt to fix it

See https://regex101.com/r/EwGGRb/1 for a quick test of new regex