### PR TITLE
Add UTF-8 encoding hints

### DIFF
--- a/src/background-firefox.ts
+++ b/src/background-firefox.ts
@@ -26,7 +26,7 @@ function detectJSON(event: chrome.webRequest.WebResponseHeadersDetails) {
       if (typeof browser !== "undefined" && "filterResponseData" in browser.webRequest) {
         // We need to change the content type to text/plain to prevent Firefox
         // from using its built-in JSON viewer.
-        header.value = "text/plain";
+        header.value = "text/plain; charset=UTF-8";
       }
     }
   }

--- a/src/viewer.css
+++ b/src/viewer.css
@@ -1,3 +1,5 @@
+@charset "UTF-8";
+
 body {
   font-family: sans-serif;
   margin: 0;


### PR DESCRIPTION
`text/plain` (vs. `application/json`) should have `charset` specified:

-   https://datatracker.ietf.org/doc/html/rfc1521#section-7.1.1

Apart from that, specify `@charset` in `viewer.css` to ensure correct decoding of generated `content` declarations:

-   https://developer.mozilla.org/en-US/docs/Web/CSS/@charset

Fixes #218