### PR TITLE
A collection of small style adjustments

### DIFF
--- a/src/jsonformatter.ts
+++ b/src/jsonformatter.ts
@@ -217,6 +217,7 @@ function toHTML(content: string, title: string) {
   return `<!DOCTYPE html>
 <html><head><title>${htmlEncode(title)}</title>
 <meta charset="utf-8">
+<meta name="color-scheme" content="light dark">
 <link rel="stylesheet" type="text/css" href="${chrome.runtime.getURL("viewer.css")}">
 </head><body>
 ${content}

--- a/src/viewer.css
+++ b/src/viewer.css
@@ -191,3 +191,7 @@ h1 {
 .string, :any-link {
   word-break: break-all;
 }
+
+:is(.spacer, :not(.quoted) > .q)::selection {
+  background-color: transparent;
+}

--- a/src/viewer.css
+++ b/src/viewer.css
@@ -187,3 +187,7 @@ h1 {
   display: inline-block;
   width: 0px;
 }
+
+.string, :any-link {
+  word-break: break-all;
+}

--- a/src/viewer.css
+++ b/src/viewer.css
@@ -43,6 +43,7 @@ body {
 
 .collapsible.collapsed {
   height: 1.2em;
+  height: 1lh;
   width: 1em;
   display: inline-block;
   overflow: hidden;


### PR DESCRIPTION
These are small style adjustments I'm currently using via ["user styles"](https://github.com/openstyles/stylus).  See the individual commit messages for some more details, while I'll leave some _Before_ and _After_ screenshots here:

-   <details>
    <summary>Give <code>.collapsible.collapsed { height: 1lh }</code></summary>

    <br>Using `#json { line-height: 2 }`:

    |  |  |
    ---|---
    ![collapsed-before](https://github.com/user-attachments/assets/61c3c012-784f-44e0-9035-44ae9a507fd2) | ![collapsed-after](https://github.com/user-attachments/assets/b96ee358-fcce-4fe4-8f97-b6ffabc2169d)
    </details>

-   <details open>
    <summary>Avoid horizontal scroll with very long string or link values</summary>
    <br>

    |  |  |
    ---|---
    ![long-link-before](https://github.com/user-attachments/assets/75fedc01-d707-4d43-a6d4-e05c5bc145d5) | ![long-link-after](https://github.com/user-attachments/assets/21a21c67-918d-4546-824e-e9c361851a08)
    ![long-string-before](https://github.com/user-attachments/assets/2754ade2-96dd-42a9-b5a5-a4ab4334cc88) | ![long-string-after](https://github.com/user-attachments/assets/1e67ac95-85bb-4d1c-b1ab-7426f3ef5239)

    Firefox breaks somewhat more by default:

    |  |  |
    ---|---
    ![firefox-long-before](https://github.com/user-attachments/assets/79aabd23-4813-4006-944b-0c143692acbf) | ![firefox-long-after](https://github.com/user-attachments/assets/00b67ce0-b88f-4de6-8781-78fabe440948)
    </details>

-   <details>
    <summary>Specify <code>&lt;meta name="color-scheme" content="light dark"></code></summary>
    <br>

    |  |  |
    ---|---
    ![selection-color-before](https://github.com/user-attachments/assets/6ce3eaa9-d060-4239-95cc-ba509e0e0810) | ![selection-color-after](https://github.com/user-attachments/assets/d24d5e2f-996c-4747-8880-f1059e6f4695)

    Firefox View > Page Style > No Style:

    |  |  |
    ---|---
    ![no-style-before](https://github.com/user-attachments/assets/309f25f8-7b37-4cce-9976-7d5003c78836) | ![no-style-after](https://github.com/user-attachments/assets/e5788a63-c2cc-443a-a134-4bda54f910e3)
    </details>

-   <details>
    <summary>Force transparent background for "collapsed" text selection</summary>
    <br>

    |  |  |
    ---|---
    ![translucent-selection-before](https://github.com/user-attachments/assets/570ece4d-9f8c-43fa-bf50-fef02ca95f25) | ![translucent-selection-after](https://github.com/user-attachments/assets/d24d5e2f-996c-4747-8880-f1059e6f4695)
    </details>

-   <details>
    <summary><s>Specify widths/lengths in <code>ch</code> unit</s></summary>
    <br>

    |  |  |
    ---|---
    ![indent-before](https://github.com/user-attachments/assets/f51abcc4-301b-4861-a03d-b4582847550b) | ![indent-after](https://github.com/user-attachments/assets/8bc90770-6fe5-43e3-93d4-4cecb18bb8a7)
    </details>

-   <s>Enlarge `.collapser` width/click-area</s>

See if you may be interested in any of these.
