### PR TITLE
Ignore reponses not associated with a tab.

### DIFF
--- a/src/background-firefox.ts
+++ b/src/background-firefox.ts
@@ -16,6 +16,12 @@ function detectJSON(event: chrome.webRequest.WebResponseHeadersDetails) {
   if (!event.responseHeaders || isRedirect(event.statusCode)) {
     return;
   }
+
+  if (event.tabId == -1) {
+    console.log("Ignoring response with application/json content-type because tabId == -1:", event.url);
+    return {};
+  }
+
   for (const header of event.responseHeaders) {
     if (
       header.name.toLowerCase() === "content-type" &&


### PR DESCRIPTION
This fixes #210 for me. The root cause seems to be that the relationship between frames and service workers has been [contentious and shifty over time](https://issues.chromium.org/issues/40540617).

Based on my debugging, when the request to the SharePoint site for a page like `https://...sharepoint.com/.../CollabHome.apsx` is made, the response seen by JSONView has a header `content-type: application/json`. However, with JSONView disabled, in the browser dev tools network panel, that same response has a header `content-type: text/html;  charset=utf-8`. This makes me suspect JSONView is seeing the response prior to it being transformed by the service worker.

The empty JSON responses I see from SharePoint do have `tabId == -1` as mentioned in that linked report. Based on the discussion in that report though I'm not sure how stable that relationship will be. We could instead use a more direct workaround for the parsing issue by ignoring empty JSON documents. I tested that approach too and it does fix SharePoint sites for me. However, if I'm right about the service workers, then such a workaround would carry the risk of an empty JSON response being hydrated by a service worker into a non-empty JSON response that would then be ignored by JSONView. Something to keep in mind if the `tabId == -1` condition ever stops working.

The same change should be applicable to the chrome code but I don't have a system on hand to test that right now.